### PR TITLE
Add dynamic Planificador with PDF export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+.env

--- a/Front-Turismo-SDE-master/db.php
+++ b/Front-Turismo-SDE-master/db.php
@@ -1,0 +1,21 @@
+<?php
+$host = 'localhost';
+$db   = 'oficinaturismorecorridos';
+$user = 'tu_usuario';
+$pass = 'tu_contraseña';
+$charset = 'utf8mb4';
+
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    echo 'Conexión fallida: ' . $e->getMessage();
+    exit;
+}
+?>

--- a/Front-Turismo-SDE-master/export_pdf.php
+++ b/Front-Turismo-SDE-master/export_pdf.php
@@ -1,0 +1,36 @@
+<?php
+require 'db.php';
+require 'vendor/autoload.php';
+
+use Dompdf\Dompdf;
+
+$routeId = isset($_GET['route']) ? (int)$_GET['route'] : 1;
+
+$destinosStmt = $pdo->prepare(
+    "SELECT d.Nombre FROM destinos d
+     JOIN rutas_lugares rl ON rl.IdLugar = d.IdLugar
+     WHERE rl.IdRecorrido = :routeId LIMIT 3"
+);
+$destinosStmt->execute(['routeId' => $routeId]);
+$destinos = $destinosStmt->fetchAll();
+
+$rutaStmt = $pdo->prepare("SELECT Duracion, CostoDelRecorrido FROM rutas WHERE IdRecorrido = :routeId LIMIT 1");
+$rutaStmt->execute(['routeId' => $routeId]);
+$ruta = $rutaStmt->fetch();
+
+$html = '<h1>Planificador</h1>';
+$html .= '<ul>';
+foreach ($destinos as $d) {
+    $html .= '<li>'.htmlspecialchars($d['Nombre']).'</li>';
+}
+$html .= '</ul>';
+$html .= '<p>Duración estimada: '.htmlspecialchars($ruta['Duracion']).' min</p>';
+$html .= '<p>Costo total: $'.htmlspecialchars($ruta['CostoDelRecorrido']).'</p>';
+
+$dompdf = new Dompdf();
+$dompdf->loadHtml($html);
+$dompdf->setPaper('A4', 'portrait');
+$dompdf->render();
+$dompdf->stream('planificador.pdf', ['Attachment' => false]);
+?>
+

--- a/Front-Turismo-SDE-master/index.html
+++ b/Front-Turismo-SDE-master/index.html
@@ -167,7 +167,7 @@
       </section>
     </a>
     
-    <a href="./planificador.html">
+    <a href="./planificador.php?route=1">
       <section class="mb-5">
         <div class="card bg-dark-subtle text-light p-0" style="border: 0px; border-radius: 12px;">
           <div class="card-body tarjeta-centro p-0">

--- a/Front-Turismo-SDE-master/planificador.php
+++ b/Front-Turismo-SDE-master/planificador.php
@@ -1,0 +1,150 @@
+<?php
+require "db.php";
+$routeId = isset($_GET['route']) ? (int)$_GET['route'] : 1;
+
+$destinosStmt = $pdo->prepare(
+    "SELECT d.Nombre FROM destinos d
+     JOIN rutas_lugares rl ON rl.IdLugar = d.IdLugar
+     WHERE rl.IdRecorrido = :routeId LIMIT 3"
+);
+$destinosStmt->execute(['routeId' => $routeId]);
+$destinos = $destinosStmt->fetchAll();
+
+$rutaStmt = $pdo->prepare("SELECT Duracion, CostoDelRecorrido FROM rutas WHERE IdRecorrido = :routeId LIMIT 1");
+$rutaStmt->execute(['routeId' => $routeId]);
+$ruta = $rutaStmt->fetch();
+?>
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Destinos - Turismo - Santiago del Estero</title>
+  <link rel="icon" href="./img/favico/favico.png" type="image/x-icon">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" crossorigin="anonymous">
+
+  <link rel="stylesheet" href="./css/planificador-style.css">
+  <link rel="stylesheet" href="./css/planificador-form-style.css">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+  <!-- FUENTES -->
+
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
+
+  <link href="https://fonts.googleapis.com/css2?family=Bungee&display=swap" rel="stylesheet">
+
+</head>
+
+<body class="bg-body bebas-neue-regular">
+
+  <header>
+    <!-- Barra de Navegación -->
+
+    <nav class="navbar bg-dark border-body navbar-expand-lg" data-bs-theme="dark">
+      <div class="container-fluid">
+        <a class="navbar-brand text-light ms-3" href="#"><img id="navLogo" class="img-fluid"
+            src="./img/santiago-logo.png" alt="Primera imagen" class="img-fluid"></a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+          aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
+          <ul class="navbar-nav">
+            <li class="nav-item">
+              <a class="nav-link text-light pe-5 me-5 fs-3" aria-current="page" href="#">Inicio</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link text-light pe-5 me-5 fs-3" href="#">Próximos Eventos</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link text-light pe-5 me-5 fs-3" href="#">Información</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link text-light pe-5 me-5 fs-3" href="index.html">Circuito Turistico</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+  </header>
+
+  <!-- PRINCIPAL -->
+  <main class="container pt-5">
+
+    <section class="form-check-inline me-0">
+      <h1 style="font-size: 5em;">Planificador</h1>
+    </section>
+
+    <section class="row justify-content-evenly ms-1 me-1">
+      <a href="destino.html" class="card btn btn-light col-lg-3 p-0 me-lg-3 mb-lg-3 mb-3 col-md-12 tarjeta-destinos">
+        <img src="./img/estadio-unico.jpg" class="card-img-top tarjeta-imagen" alt="...">
+        <div class="card-body">
+          <p class="card-text fs-3"><?php echo isset($destinos[0]) ? htmlspecialchars($destinos[0]['Nombre']) : ''; ?></p>
+        </div>
+      </a>
+
+      <div class="card btn btn-light col-lg-3 p-0 me-lg-3 mb-lg-3 mb-3 col-md-12 tarjeta-destinos">
+        <img src="./img/estadiode-hockey.jpg" class="card-img-top tarjeta-imagen" alt="...">
+        <div class="card-body">
+          <p class="card-text fs-3"><?php echo isset($destinos[1]) ? htmlspecialchars($destinos[1]['Nombre']) : ''; ?></p>
+        </div>
+      </div>
+
+      <div class="card btn btn-light btn btn-light col-lg-3 p-0 me-lg-3 mb-lg-3 mb-3 col-md-12 tarjeta-destinos">
+        <img src="./img/las-torres.jpg" class="card-img-top mw-100 tarjeta-imagen" alt="...">
+        <div class="card-body">
+          <p class="card-text fs-3"><?php echo isset($destinos[2]) ? htmlspecialchars($destinos[2]['Nombre']) : ''; ?></p>
+        </div>
+      </div>
+    </section>
+
+    <section class="text-center roboto-300 fs-3 mt-5">
+        <p>Duracion Estimada: <?php echo htmlspecialchars($ruta['Duracion']); ?> min</p>
+        <p>Costo Total: $<?php echo htmlspecialchars($ruta['CostoDelRecorrido']); ?></p>
+        <a href="export_pdf.php?route=<?php echo $routeId; ?>" target="_blank" class="btn btn-primary fs-4 ps-2 pt-1 pe-2 pb-1"><img class="img-pdf pe-1" src="./img/archivo-pdf.svg" alt="PDF">Exportar</a>
+    </section>
+
+    <section class="col-12 my-5">
+      <iframe class="container p-0"
+        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3530.4191404076796!2d-64.27341242469707!3d-27.76605667614902!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x943b538809306767%3A0x6a147f14e2f77597!2sEstadio%20%C3%9Anico%20Madre%20de%20Ciudades.!5e0!3m2!1ses-419!2sar!4v1747616581177!5m2!1ses-419!2sar"
+        style="border:0; height: 320px;" allowfullscreen="" loading="lazy"
+        referrerpolicy="no-referrer-when-downgrade"></iframe>
+    </section>
+  </main>
+
+  <!-- PIE DE PAGINA -->
+  <footer class="container-fluid separacion-texto mt-4">
+    <div class="row align-items-start nav-color pt-4">
+      <div
+        class="col-lg-5 col-md-12 card-footer text-light pt-sm-5 pb-sm-5 ps-3 pe-sm-5 pt-lg-5 pb-lg-5 ps-lg-5 pe-lg-5 text-light">
+        <h1 class="mb-5"><strong>Contacto</strong></h1>
+        <h4 class="mb-3"><strong>Direccion:</strong> Av. Libertad 417, Santiago del Estero</h4>
+        <h4 class="mb-3"><strong>Código Postal:</strong> G4200</h4>
+        <h4 class="mb-3"><strong>Teléfono:</strong> +54 385 421-4243</h4>
+        <h4 class="mb-3"><strong>WhatsApp:</strong> +54 385 475-7749</h4>
+        <h4 class="mb-3"><strong>Correo:</strong> <a href="mailto:santiagoturismo2021@gmail.com"
+            style="text-decoration: none; color: aliceblue;">santiagoturismo2021@gmail.com</a></h4>
+      </div>
+      <div class="flex-column text-center pt-3 pb-3 px-3 col-lg-7 col-md-12 card-footer text-light text-light">
+        <iframe
+          src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3529.743254793991!2d-64.26247042469637!3d-27.78688407613697!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x943b52115ea3ac05%3A0xb108231a9dab0636!2sSub%20Secretar%C3%ADa%20de%20Turismo%20de%20la%20Provincia%20de%20Santiago%20del%20Estero!5e0!3m2!1ses-419!2sar!4v1747236619964!5m2!1ses-419!2sar"
+          class="mapa w-75" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+      </div>
+    </div>
+    <div class="row align-items-end">
+      <div class="col card-footer text-center text-light bg-dark p-4">
+        &copy; Turismo - Santiago del Estero
+      </div>
+    </div>
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
+    crossorigin="anonymous"></script>
+</body>
+
+</html>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Turismo Santiago del Estero
+
+Este proyecto contiene una pequeña aplicaci\u00f3n de ejemplo que usa PHP y MySQL para mostrar informaci\u00f3n tur\u00edstica.
+
+## Base de datos
+
+Se incluye el archivo `oficinaturismorecorridos.sql` que contiene la estructura y datos de ejemplo. Para crear la base de datos ejecute en su servidor MySQL:
+
+```bash
+mysql -u usuario -p < oficinaturismorecorridos.sql
+```
+
+Luego actualice las credenciales en `Front-Turismo-SDE-master/db.php`.
+
+## Dependencias
+
+Para generar el PDF se usa [Dompdf](https://github.com/dompdf/dompdf). Inst\u00e1lelo mediante Composer:
+
+```bash
+composer require dompdf/dompdf
+```
+
+## Uso
+
+Abra `index.html` en su navegador y seleccione la tarjeta **Planificador**. Los datos se cargar\u00e1n desde la base de datos y podr\u00e1 exportarlos a PDF.
+


### PR DESCRIPTION
## Summary
- hook Planificador page to database using prepared statements
- show selected route info and export to PDF
- allow picking route via query parameter
- document setup steps and ignore vendor files

## Testing
- `php -l Front-Turismo-SDE-master/planificador.php`
- `php -l Front-Turismo-SDE-master/export_pdf.php`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68781edcb6548332990ca9c9647446e5